### PR TITLE
feat: add speakerID support and multi-language schedule

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,8 @@ let package = Package(
       resources: [
         .copy("../../speakers.json"),
         .copy("../../schedule.json"),
+        .copy("../../schedule_en.json"),
+        .copy("../../schedule_jp.json"),
         .copy("../../sponsors.json"),
         .copy("../../staffs.json"),
       ]
@@ -36,6 +38,8 @@ let package = Package(
         // Keep the relative path because other projects fetch the resources from the root of the project
         .copy("../../speakers.json"),
         .copy("../../schedule.json"),
+        .copy("../../schedule_en.json"),
+        .copy("../../schedule_jp.json"),
         .copy("../../sponsors.json"),
         .copy("../../staffs.json"),
       ]

--- a/Sources/SessionData/Models/DataLanguage.swift
+++ b/Sources/SessionData/Models/DataLanguage.swift
@@ -13,8 +13,8 @@ public enum DataLanguage: Sendable, CaseIterable {
   case japanese
 }
 
-public extension DataLanguage {
-  var fileNameSuffix: String {
+extension DataLanguage {
+  public var fileNameSuffix: String {
     switch self {
     case .traditionalChinese:
       return ""

--- a/Sources/SessionData/Models/DataLanguage.swift
+++ b/Sources/SessionData/Models/DataLanguage.swift
@@ -1,0 +1,27 @@
+//
+//  DataLanguage.swift
+//  SessionData
+//
+//  Created by ethanhuang on 2025/8/21.
+//
+
+import Foundation
+
+public enum DataLanguage: Sendable, CaseIterable {
+  case traditionalChinese
+  case english
+  case japanese
+}
+
+public extension DataLanguage {
+  var fileNameSuffix: String {
+    switch self {
+    case .traditionalChinese:
+      return ""
+    case .english:
+      return "_en"
+    case .japanese:
+      return "_jp"
+    }
+  }
+}

--- a/Sources/SessionData/Models/Session.swift
+++ b/Sources/SessionData/Models/Session.swift
@@ -5,6 +5,7 @@ public struct Session: Codable, Sendable, Equatable, Hashable {
   public var title: String
   public var tags: [String]
   public var speaker: String
+  public var speakerID: Speaker.ID?
   public var description: String
 
   public init(
@@ -12,12 +13,14 @@ public struct Session: Codable, Sendable, Equatable, Hashable {
     title: String,
     tags: [String],
     speaker: String,
+    speakerID: Speaker.ID?,
     description: String
   ) {
     self.time = time
     self.title = title
     self.tags = tags
     self.speaker = speaker
+    self.speakerID = speakerID
     self.description = description
   }
 }

--- a/Sources/SessionData/Models/Speaker.swift
+++ b/Sources/SessionData/Models/Speaker.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Speaker: Codable, Sendable, Equatable, Hashable {
+public struct Speaker: Codable, Sendable, Equatable, Hashable, Identifiable {
   public var id: Int
   public var name: String
   public var title: String?

--- a/Tests/SessionDataTests/LiveSessionDataClientErrorTests.swift
+++ b/Tests/SessionDataTests/LiveSessionDataClientErrorTests.swift
@@ -14,8 +14,13 @@ struct LiveSessionDataClientErrorTests {
     let testSchedule = Schedule(
       day1: [
         Session(
-          time: "09:00", title: "Cached Session", tags: [], speaker: "Cached Speaker",
-          description: "From cache")
+          time: "09:00",
+          title: "Cached Session",
+          tags: [],
+          speaker: "Cached Speaker",
+          speakerID: nil,
+          description: "From cache"
+        )
       ],
       day2: []
     )

--- a/Tests/SessionDataTests/LiveSessionDataClientTests.swift
+++ b/Tests/SessionDataTests/LiveSessionDataClientTests.swift
@@ -13,13 +13,23 @@ struct LiveSessionDataClientTests {
     let expectedSchedule = Schedule(
       day1: [
         Session(
-          time: "09:00", title: "Keynote", tags: [], speaker: "Tim Cook",
-          description: "Opening keynote")
+          time: "09:00",
+          title: "Keynote",
+          tags: [],
+          speaker: "Tim Cook",
+          speakerID: nil,
+          description: "Opening keynote"
+        )
       ],
       day2: [
         Session(
-          time: "10:00", title: "SwiftUI", tags: ["UI"], speaker: "John Doe",
-          description: "Advanced SwiftUI")
+          time: "10:00",
+          title: "SwiftUI",
+          tags: ["UI"],
+          speaker: "John Doe",
+          speakerID: nil,
+          description: "Advanced SwiftUI"
+        )
       ]
     )
 
@@ -44,11 +54,23 @@ struct LiveSessionDataClientTests {
     let expectedSchedule = Schedule(
       day1: [
         Session(
-          time: "09:00", title: "Day 1 Session", tags: [], speaker: "Speaker 1", description: "")
+          time: "09:00",
+          title: "Day 1 Session",
+          tags: [],
+          speaker: "Speaker 1",
+          speakerID: nil,
+          description: ""
+        )
       ],
       day2: [
         Session(
-          time: "10:00", title: "Day 2 Session", tags: [], speaker: "Speaker 2", description: "")
+          time: "10:00",
+          title: "Day 2 Session",
+          tags: [],
+          speaker: "Speaker 2",
+          speakerID: nil,
+          description: ""
+        )
       ]
     )
 
@@ -77,8 +99,13 @@ struct LiveSessionDataClientTests {
     let cachedSchedule = Schedule(
       day1: [
         Session(
-          time: "09:00", title: "Cached Session", tags: [], speaker: "Cached Speaker",
-          description: "")
+          time: "09:00",
+          title: "Cached Session",
+          tags: [],
+          speaker: "Cached Speaker",
+          speakerID: nil,
+          description: ""
+        )
       ],
       day2: []
     )
@@ -106,8 +133,13 @@ struct LiveSessionDataClientTests {
     let bundleSchedule = Schedule(
       day1: [
         Session(
-          time: "09:00", title: "Bundle Session", tags: [], speaker: "Bundle Speaker",
-          description: "")
+          time: "09:00",
+          title: "Bundle Session",
+          tags: [],
+          speaker: "Bundle Speaker",
+          speakerID: nil,
+          description: ""
+        )
       ],
       day2: []
     )

--- a/Tests/SessionDataTests/SessionDataClientTests.swift
+++ b/Tests/SessionDataTests/SessionDataClientTests.swift
@@ -39,9 +39,21 @@ struct SessionDataClientTests {
   func scheduleDayFiltering() async throws {
     // Create a test client with known data
     let testSession1 = Session(
-      time: "09:00", title: "Day 1 Session", tags: [], speaker: "Speaker 1", description: "")
+      time: "09:00",
+      title: "Day 1 Session",
+      tags: [],
+      speaker: "Speaker 1",
+      speakerID: nil,
+      description: ""
+    )
     let testSession2 = Session(
-      time: "10:00", title: "Day 2 Session", tags: [], speaker: "Speaker 2", description: "")
+      time: "10:00",
+      title: "Day 2 Session",
+      tags: [],
+      speaker: "Speaker 2",
+      speakerID: nil,
+      description: ""
+    )
 
     let client = SessionDataClient(
       fetchSchedules: { day in

--- a/Tests/SessionDataTests/SessionDataTests.swift
+++ b/Tests/SessionDataTests/SessionDataTests.swift
@@ -22,7 +22,8 @@ struct SessionDataTests {
 
   @Test("Schedule JSON can be decoded", arguments: DataLanguage.allCases)
   func scheduleJSONDecoding(dataLanguage: DataLanguage) throws {
-    let jsonURL = Bundle.module.url(forResource: "schedule\(dataLanguage.fileNameSuffix)", withExtension: "json")!
+    let jsonURL = Bundle.module.url(
+      forResource: "schedule\(dataLanguage.fileNameSuffix)", withExtension: "json")!
     let data = try Data(contentsOf: jsonURL)
     let schedule = try JSONDecoder().decode(Schedule.self, from: data)
 
@@ -39,7 +40,8 @@ struct SessionDataTests {
     let speakerIDs = Set(speakers.map { $0.id })
 
     // Load schedule
-    let scheduleURL = Bundle.module.url(forResource: "schedule\(dataLanguage.fileNameSuffix)", withExtension: "json")!
+    let scheduleURL = Bundle.module.url(
+      forResource: "schedule\(dataLanguage.fileNameSuffix)", withExtension: "json")!
     let scheduleData = try Data(contentsOf: scheduleURL)
     let schedule = try JSONDecoder().decode(Schedule.self, from: scheduleData)
 

--- a/Tests/SessionDataTests/SessionDataTests.swift
+++ b/Tests/SessionDataTests/SessionDataTests.swift
@@ -20,14 +20,40 @@ struct SessionDataTests {
     #expect(ids.count == uniqueIDs.count, "Speakers should have unique ids")
   }
 
-  @Test("Schedule JSON can be decoded")
-  func scheduleJSONDecoding() throws {
-    let jsonURL = Bundle.module.url(forResource: "schedule", withExtension: "json")!
+  @Test("Schedule JSON can be decoded", arguments: DataLanguage.allCases)
+  func scheduleJSONDecoding(dataLanguage: DataLanguage) throws {
+    let jsonURL = Bundle.module.url(forResource: "schedule\(dataLanguage.fileNameSuffix)", withExtension: "json")!
     let data = try Data(contentsOf: jsonURL)
     let schedule = try JSONDecoder().decode(Schedule.self, from: data)
 
     #expect(!schedule.day1.isEmpty)
     #expect(!schedule.day2.isEmpty)
+  }
+
+  @Test("All session speakerIDs can be found in speakers", arguments: DataLanguage.allCases)
+  func sessionSpeakerIDsExistInSpeakers(dataLanguage: DataLanguage) throws {
+    // Load speakers
+    let speakersURL = Bundle.module.url(forResource: "speakers", withExtension: "json")!
+    let speakersData = try Data(contentsOf: speakersURL)
+    let speakers = try JSONDecoder().decode([Speaker].self, from: speakersData)
+    let speakerIDs = Set(speakers.map { $0.id })
+
+    // Load schedule
+    let scheduleURL = Bundle.module.url(forResource: "schedule\(dataLanguage.fileNameSuffix)", withExtension: "json")!
+    let scheduleData = try Data(contentsOf: scheduleURL)
+    let schedule = try JSONDecoder().decode(Schedule.self, from: scheduleData)
+
+    // Gather all sessions from both days
+    let allSessions = schedule.day1 + schedule.day2
+
+    // Check that every session with a speakerID has that ID in speakers
+    for session in allSessions {
+      if let speakerID = session.speakerID {
+        #expect(
+          speakerIDs.contains(speakerID),
+          "Session '\(session.title)' has unknown speakerID: \(speakerID)")
+      }
+    }
   }
 
   @Test("Sponsors JSON can be decoded")

--- a/Tests/SessionDataTests/SessionDataTests.swift
+++ b/Tests/SessionDataTests/SessionDataTests.swift
@@ -13,6 +13,11 @@ struct SessionDataTests {
     let speakers = try JSONDecoder().decode([Speaker].self, from: data)
 
     #expect(!speakers.isEmpty)
+
+    // Ensure speakers have unique id
+    let ids = speakers.map { $0.id }
+    let uniqueIDs = Set(ids)
+    #expect(ids.count == uniqueIDs.count, "Speakers should have unique ids")
   }
 
   @Test("Schedule JSON can be decoded")


### PR DESCRIPTION
## Summary
- Added `speakerID` property to Session model for linking sessions to speakers
- Implemented multi-language schedule support with DataLanguage enum (Traditional Chinese, English, Japanese)
- Added comprehensive tests to validate speaker referential integrity across all language variants
- Updated Package.swift to include new schedule files (schedule_en.json, schedule_jp.json)

## Test plan
- [x] All 23 tests pass
- [x] Code formatting verified with swift-format
- [x] Session speakerID validation works across all language variants
- [x] Backwards compatibility maintained with optional speakerID field

🤖 Generated with [Claude Code](https://claude.ai/code)