### PR TITLE
feat: improve multi-language JSON consistency tests with source of truth approach

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     .iOS(.v14),
     .macOS(.v11),
     .tvOS(.v14),
-    .watchOS(.v7)
+    .watchOS(.v7),
   ],
   products: [
     // Products define the executables and libraries a package produces, making them visible to other packages.
@@ -24,6 +24,8 @@ let package = Package(
       name: "SessionData",
       resources: [
         .copy("../../speakers.json"),
+        .copy("../../speakers_en.json"),
+        .copy("../../speakers_jp.json"),
         .copy("../../schedule.json"),
         .copy("../../schedule_en.json"),
         .copy("../../schedule_jp.json"),
@@ -37,6 +39,8 @@ let package = Package(
       resources: [
         // Keep the relative path because other projects fetch the resources from the root of the project
         .copy("../../speakers.json"),
+        .copy("../../speakers_en.json"),
+        .copy("../../speakers_jp.json"),
         .copy("../../schedule.json"),
         .copy("../../schedule_en.json"),
         .copy("../../schedule_jp.json"),

--- a/Sources/SessionData/Models/DataLanguage.swift
+++ b/Sources/SessionData/Models/DataLanguage.swift
@@ -14,6 +14,14 @@ public enum DataLanguage: Sendable, CaseIterable {
 }
 
 extension DataLanguage {
+  public var speakersFileName: String {
+    "speakers\(fileNameSuffix)"
+  }
+
+  public var scheduleFileName: String {
+    "schedule\(fileNameSuffix)"
+  }
+
   public var fileNameSuffix: String {
     switch self {
     case .traditionalChinese:

--- a/Tests/SessionDataTests/SessionDataTests.swift
+++ b/Tests/SessionDataTests/SessionDataTests.swift
@@ -21,62 +21,75 @@ struct SessionDataTests {
     #expect(ids.count == uniqueIDs.count, "Speakers should have unique ids")
   }
 
-  @Test("Speakers JSON files have the same properties except name, title, and intro")
+  @Test("Translated speakers JSON files match source of truth for non-translatable fields")
   func speakersJSONPropertiesConsistency() throws {
-    // 讀取所有語言的 speakers 檔案，依 id 分組，檢查同 id 的 speaker 除了 name 與 title 外其他欄位都相同
-    let allSpeakersByLanguage: [[Speaker]] = try DataLanguage.allCases.map { lang in
-      let url = Bundle.module.url(
-        forResource: "speakers\(lang.fileNameSuffix)", withExtension: "json")!
-      let data = try Data(contentsOf: url)
-      return try JSONDecoder().decode([Speaker].self, from: data)
-    }
+    let sourceOfTruthSpeakers = try loadSpeakers(for: .traditionalChinese)
+    let sourceByID = Dictionary(uniqueKeysWithValues: sourceOfTruthSpeakers.map { ($0.id, $0) })
 
-    // 建立 id -> [Speaker] 的對照表
-    var speakersByID: [Int: [Speaker]] = [:]
-    for speakers in allSpeakersByLanguage {
-      for speaker in speakers {
-        speakersByID[speaker.id, default: []].append(speaker)
-      }
-    }
+    let translatedLanguages = DataLanguage.allCases.filter { $0 != .traditionalChinese }
 
-    // 檢查每個 id 的 speakers，除了 name 與 title 外其他欄位都要相同
-    for (id, speakers) in speakersByID {
-      guard let first = speakers.first else { continue }
-      for other in speakers.dropFirst() {
-        // 比較除了 name 與 title 以外的欄位
-        let firstComparable = Speaker(
-          id: first.id,
-          name: "",  // ignore
-          title: nil,  // ignore
-          intro: "",  // ignore
-          photo: first.photo,
-          url: first.url,
-          fb: first.fb,
-          github: first.github,
-          linkedin: first.linkedin,
-          threads: first.threads,
-          x: first.x,
-          ig: first.ig
-        )
-        let otherComparable = Speaker(
-          id: other.id,
-          name: "",  // ignore
-          title: nil,  // ignore
-          intro: "",  // ignore
-          photo: other.photo,
-          url: other.url,
-          fb: other.fb,
-          github: other.github,
-          linkedin: other.linkedin,
-          threads: other.threads,
-          x: other.x,
-          ig: other.ig
-        )
-        #expect(
-          firstComparable == otherComparable,
-          "Speaker with id \(id) has mismatched properties (except name/title) between languages"
+    for language in translatedLanguages {
+      let translatedSpeakers = try loadSpeakers(for: language)
+      let fileName = "\(language.speakersFileName).json"
+
+      for translatedSpeaker in translatedSpeakers {
+        guard let sourceSpeaker = sourceByID[translatedSpeaker.id] else {
+          Issue.record(
+            "Speaker ID \(translatedSpeaker.id) exists in \(fileName) but not in source speakers.json"
+          )
+          continue
+        }
+
+        validateSpeakerFieldsMatch(
+          source: sourceSpeaker,
+          translated: translatedSpeaker,
+          translatedFileName: fileName
         )
       }
+
+      let translatedIDs = Set(translatedSpeakers.map(\.id))
+      let sourceIDs = Set(sourceOfTruthSpeakers.map(\.id))
+      let missingInTranslation = sourceIDs.subtracting(translatedIDs)
+
+      for missingID in missingInTranslation {
+        Issue.record(
+          "Speaker ID \(missingID) exists in source speakers.json but missing in \(fileName)")
+      }
+    }
+  }
+
+  private func loadSpeakers(for language: DataLanguage) throws -> [Speaker] {
+    let url = Bundle.module.url(
+      forResource: language.speakersFileName,
+      withExtension: "json"
+    )!
+    let data = try Data(contentsOf: url)
+    return try JSONDecoder().decode([Speaker].self, from: data)
+  }
+
+  private func validateSpeakerFieldsMatch(
+    source: Speaker,
+    translated: Speaker,
+    translatedFileName: String
+  ) {
+    let urlFields: [(keyPath: KeyPath<Speaker, URL?>, name: String)] = [
+      (\.photo, "photo"),
+      (\.url, "personal"),
+      (\.fb, "Facebook"),
+      (\.github, "GitHub"),
+      (\.linkedin, "LinkedIn"),
+      (\.threads, "Threads"),
+      (\.x, "X"),
+      (\.ig, "Instagram"),
+    ]
+
+    for (keyPath, fieldName) in urlFields {
+      let sourceValue = source[keyPath: keyPath]
+      let translatedValue = translated[keyPath: keyPath]
+      #expect(
+        sourceValue == translatedValue,
+        "Fix \(translatedFileName): Speaker \(source.id) \(fieldName) URL should be '\(sourceValue?.absoluteString ?? "nil")' but is '\(translatedValue?.absoluteString ?? "nil")'"
+      )
     }
   }
 
@@ -117,6 +130,98 @@ struct SessionDataTests {
           "Session '\(session.title)' has unknown speakerID: \(speakerID)")
       }
     }
+  }
+
+  @Test("Translated schedule JSON files match source of truth for speakerID and time")
+  func schedulesJSONPropertiesConsistency() throws {
+    let sourceSchedule = try loadSchedule(for: .traditionalChinese)
+
+    let translatedLanguages = DataLanguage.allCases.filter { $0 != .traditionalChinese }
+
+    for language in translatedLanguages {
+      let translatedSchedule = try loadSchedule(for: language)
+      let fileName = "\(language.scheduleFileName).json"
+
+      validateScheduleConsistency(
+        source: sourceSchedule,
+        translated: translatedSchedule,
+        translatedFileName: fileName
+      )
+    }
+  }
+
+  private func loadSchedule(for language: DataLanguage) throws -> Schedule {
+    let url = Bundle.module.url(
+      forResource: language.scheduleFileName,
+      withExtension: "json"
+    )!
+    let data = try Data(contentsOf: url)
+    return try JSONDecoder().decode(Schedule.self, from: data)
+  }
+
+  private func validateScheduleConsistency(
+    source: Schedule,
+    translated: Schedule,
+    translatedFileName: String
+  ) {
+    #expect(
+      source.day1.count == translated.day1.count,
+      "Fix \(translatedFileName): Day1 should have \(source.day1.count) sessions but has \(translated.day1.count)"
+    )
+    #expect(
+      source.day2.count == translated.day2.count,
+      "Fix \(translatedFileName): Day2 should have \(source.day2.count) sessions but has \(translated.day2.count)"
+    )
+
+    validateSessionConsistency(
+      source.day1, translated.day1, day: 1, translatedFileName: translatedFileName)
+    validateSessionConsistency(
+      source.day2, translated.day2, day: 2, translatedFileName: translatedFileName)
+  }
+
+  private func validateSessionConsistency(
+    _ sourceSessions: [Session],
+    _ translatedSessions: [Session],
+    day: Int,
+    translatedFileName: String
+  ) {
+    for (sessionIndex, (sourceSession, translatedSession)) in zip(
+      sourceSessions, translatedSessions
+    ).enumerated() {
+      validateSessionField(
+        sourceSession, translatedSession,
+        keyPath: \.speakerID,
+        fieldName: "speakerID",
+        formatter: { String(describing: $0) },
+        day: day, sessionIndex: sessionIndex, translatedFileName: translatedFileName
+      )
+
+      validateSessionField(
+        sourceSession, translatedSession,
+        keyPath: \.time,
+        fieldName: "time",
+        formatter: { "'\($0)'" },
+        day: day, sessionIndex: sessionIndex, translatedFileName: translatedFileName
+      )
+    }
+  }
+
+  private func validateSessionField<T: Equatable>(
+    _ source: Session,
+    _ translated: Session,
+    keyPath: KeyPath<Session, T>,
+    fieldName: String,
+    formatter: (T) -> String,
+    day: Int,
+    sessionIndex: Int,
+    translatedFileName: String
+  ) {
+    let sourceValue = source[keyPath: keyPath]
+    let translatedValue = translated[keyPath: keyPath]
+    #expect(
+      sourceValue == translatedValue,
+      "Fix \(translatedFileName): Day\(day) Session\(sessionIndex) \(fieldName) should be \(formatter(sourceValue)) but is \(formatter(translatedValue))"
+    )
   }
 
   @Test("Sponsors JSON can be decoded")

--- a/Tests/SessionDataTests/SessionDataTests.swift
+++ b/Tests/SessionDataTests/SessionDataTests.swift
@@ -6,9 +6,10 @@ import Testing
 @Suite("Session Data JSON Validation")
 struct SessionDataTests {
 
-  @Test("Speakers JSON can be decoded")
-  func speakersJSONDecoding() throws {
-    let jsonURL = Bundle.module.url(forResource: "speakers", withExtension: "json")!
+  @Test("Speakers JSON can be decoded", arguments: DataLanguage.allCases)
+  func speakersJSONDecoding(dataLanguage: DataLanguage) throws {
+    let jsonURL = Bundle.module.url(
+      forResource: "speakers\(dataLanguage.fileNameSuffix)", withExtension: "json")!
     let data = try Data(contentsOf: jsonURL)
     let speakers = try JSONDecoder().decode([Speaker].self, from: data)
 
@@ -18,6 +19,64 @@ struct SessionDataTests {
     let ids = speakers.map { $0.id }
     let uniqueIDs = Set(ids)
     #expect(ids.count == uniqueIDs.count, "Speakers should have unique ids")
+  }
+
+  @Test("Speakers JSON files have the same properties except name, title, and intro")
+  func speakersJSONPropertiesConsistency() throws {
+    // 讀取所有語言的 speakers 檔案，依 id 分組，檢查同 id 的 speaker 除了 name 與 title 外其他欄位都相同
+    let allSpeakersByLanguage: [[Speaker]] = try DataLanguage.allCases.map { lang in
+      let url = Bundle.module.url(forResource: "speakers\(lang.fileNameSuffix)", withExtension: "json")!
+      let data = try Data(contentsOf: url)
+      return try JSONDecoder().decode([Speaker].self, from: data)
+    }
+    
+    // 建立 id -> [Speaker] 的對照表
+    var speakersByID: [Int: [Speaker]] = [:]
+    for speakers in allSpeakersByLanguage {
+      for speaker in speakers {
+        speakersByID[speaker.id, default: []].append(speaker)
+      }
+    }
+    
+    // 檢查每個 id 的 speakers，除了 name 與 title 外其他欄位都要相同
+    for (id, speakers) in speakersByID {
+      guard let first = speakers.first else { continue }
+      for other in speakers.dropFirst() {
+        // 比較除了 name 與 title 以外的欄位
+        let firstComparable = Speaker(
+          id: first.id,
+          name: "", // ignore
+          title: nil, // ignore
+          intro: "", // ignore
+          photo: first.photo,
+          url: first.url,
+          fb: first.fb,
+          github: first.github,
+          linkedin: first.linkedin,
+          threads: first.threads,
+          x: first.x,
+          ig: first.ig
+        )
+        let otherComparable = Speaker(
+          id: other.id,
+          name: "", // ignore
+          title: nil, // ignore
+          intro: "", // ignore
+          photo: other.photo,
+          url: other.url,
+          fb: other.fb,
+          github: other.github,
+          linkedin: other.linkedin,
+          threads: other.threads,
+          x: other.x,
+          ig: other.ig
+        )
+        #expect(
+          firstComparable == otherComparable,
+          "Speaker with id \(id) has mismatched properties (except name/title) between languages"
+        )
+      }
+    }
   }
 
   @Test("Schedule JSON can be decoded", arguments: DataLanguage.allCases)
@@ -34,7 +93,8 @@ struct SessionDataTests {
   @Test("All session speakerIDs can be found in speakers", arguments: DataLanguage.allCases)
   func sessionSpeakerIDsExistInSpeakers(dataLanguage: DataLanguage) throws {
     // Load speakers
-    let speakersURL = Bundle.module.url(forResource: "speakers", withExtension: "json")!
+    let speakersURL = Bundle.module.url(
+      forResource: "speakers\(dataLanguage.fileNameSuffix)", withExtension: "json")!
     let speakersData = try Data(contentsOf: speakersURL)
     let speakers = try JSONDecoder().decode([Speaker].self, from: speakersData)
     let speakerIDs = Set(speakers.map { $0.id })

--- a/Tests/SessionDataTests/SessionDataTests.swift
+++ b/Tests/SessionDataTests/SessionDataTests.swift
@@ -25,11 +25,12 @@ struct SessionDataTests {
   func speakersJSONPropertiesConsistency() throws {
     // 讀取所有語言的 speakers 檔案，依 id 分組，檢查同 id 的 speaker 除了 name 與 title 外其他欄位都相同
     let allSpeakersByLanguage: [[Speaker]] = try DataLanguage.allCases.map { lang in
-      let url = Bundle.module.url(forResource: "speakers\(lang.fileNameSuffix)", withExtension: "json")!
+      let url = Bundle.module.url(
+        forResource: "speakers\(lang.fileNameSuffix)", withExtension: "json")!
       let data = try Data(contentsOf: url)
       return try JSONDecoder().decode([Speaker].self, from: data)
     }
-    
+
     // 建立 id -> [Speaker] 的對照表
     var speakersByID: [Int: [Speaker]] = [:]
     for speakers in allSpeakersByLanguage {
@@ -37,7 +38,7 @@ struct SessionDataTests {
         speakersByID[speaker.id, default: []].append(speaker)
       }
     }
-    
+
     // 檢查每個 id 的 speakers，除了 name 與 title 外其他欄位都要相同
     for (id, speakers) in speakersByID {
       guard let first = speakers.first else { continue }
@@ -45,9 +46,9 @@ struct SessionDataTests {
         // 比較除了 name 與 title 以外的欄位
         let firstComparable = Speaker(
           id: first.id,
-          name: "", // ignore
-          title: nil, // ignore
-          intro: "", // ignore
+          name: "",  // ignore
+          title: nil,  // ignore
+          intro: "",  // ignore
           photo: first.photo,
           url: first.url,
           fb: first.fb,
@@ -59,9 +60,9 @@ struct SessionDataTests {
         )
         let otherComparable = Speaker(
           id: other.id,
-          name: "", // ignore
-          title: nil, // ignore
-          intro: "", // ignore
+          name: "",  // ignore
+          title: nil,  // ignore
+          intro: "",  // ignore
           photo: other.photo,
           url: other.url,
           fb: other.fb,


### PR DESCRIPTION
## Summary

- Add comprehensive schedule JSON consistency validation for multi-language support
- Refactor existing speakers JSON consistency tests to use source of truth approach  
- Utilize DataLanguage properties for cleaner, more maintainable code
- Implement key path-based validation to eliminate code duplication

## Key Improvements

### New Schedule JSON Consistency Tests
- **Added from scratch**: `schedulesJSONPropertiesConsistency` test to validate schedule translations
- Ensures `speakerID` and `time` consistency across all language versions
- Validates session counts match between language versions
- Detects missing or extra sessions in translated files

### Source of Truth Architecture
- **Traditional Chinese files** (`speakers.json`, `schedule.json`) are the authoritative source
- **Translated files** (`speakers_en.json`, `speakers_jp.json`, `schedule_en.json`, `schedule_jp.json`) are validated against the source
- Clear distinction between source data and translations

### Precise Error Reporting  
When tests fail, you get actionable error messages like:
- `"Fix schedule_en.json: Day1 Session2 speakerID should be Optional(5) but is nil"`
- `"Fix speakers_jp.json: Speaker 42 GitHub URL should be 'https://github.com/user' but is 'nil'"`

Errors specify:
- **Which file** to edit (`speakers_en.json`)  
- **Which record** has the issue (`Speaker 42`, `Day1 Session2`)
- **Which field** is wrong (`GitHub URL`, `speakerID`)
- **What the correct value should be** (`should be 'X' but is 'Y'`)

### Enhanced Existing Speakers Tests
- Refactored to use source of truth approach (was comparing all languages to each other)
- Improved error messages with specific file and field information
- Added detection of missing speakers in translated files

### Code Quality Improvements
- **Key path validation**: Eliminated duplicate URL field checks using Swift key paths
- **Generic validation functions**: Type-safe field validation with custom formatting
- **DataLanguage integration**: Uses `speakersFileName` and `scheduleFileName` properties
- **Future-proof**: Automatically includes new languages added to `DataLanguage.allCases`

## Test Coverage

### Speakers JSON Validation (Enhanced)
- ✅ Non-translatable fields (URLs, IDs) must match source exactly
- ✅ Detects missing speakers in translated files  
- ✅ Reports extra speakers not in source
- ✅ Field-specific error messages for easy debugging

### Schedule JSON Validation (New)
- ✅ Session counts must match between languages
- ✅ SpeakerID consistency across all sessions
- ✅ Time consistency across all sessions
- ✅ Day-by-day and session-by-session validation

## Benefits

1. **Complete Multi-language Validation**: Now covers both speakers and schedules data consistency
2. **Easier Debugging**: Instant identification of exactly what needs to be fixed
3. **Scalable**: New languages automatically included in validation
4. **Maintainable**: Centralized validation logic with minimal duplication
5. **Type-safe**: Swift key paths ensure compile-time correctness

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>