### PR TITLE
feat: update 13's information across multiple languages

### DIFF
--- a/speakers.json
+++ b/speakers.json
@@ -362,14 +362,14 @@
   {
     "id": 25,
     "name": "13",
-    "title": "iOS Developer+",
-    "intro": "喜歡分享，不賣焦慮。Love being inspired and sharing inspiration. ➕iOS Developer+、📰Apple 開發者週報、🎙️weak self podcast",
+    "title": "Apple 開發者週報作者、weak self podcast 主持人。歡迎訂閱 13+ 專欄",
+    "intro": "喜歡分享，不賣焦慮。Love being inspired and sharing inspiration. ➕13+、📰Apple 開發者週報、🎙️weak self podcast",
     "photo": "https://raw.githubusercontent.com/iplayground/SessionData/2025/v1/images/speakers/speaker_13.jpg",
-    "url": "https://www.ethanhuang13.com",
+    "url": "https://ethanhuang13.plus",
     "fb": "",
     "github": "https://github.com/ethanhuang13",
     "linkedin": "",
-    "threads": "https://threads.net/ethanhuang13",
+    "threads": "https://threads.com/ethanhuang13",
     "x": "https://x.com/ethanhuang13",
     "hackMD": "",
     "seminar": ""

--- a/speakers_en.json
+++ b/speakers_en.json
@@ -362,14 +362,14 @@
   {
     "id": 25,
     "name": "13",
-    "title": "iOS Developer+",
-    "intro": "喜歡分享，不賣焦慮。Love being inspired and sharing inspiration. ➕iOS Developer+、📰Apple 開發者週報、🎙️weak self podcast",
+    "title": "Apple Dev Weekly author, weak self podcast host. Welcome to subscribe 13+",
+    "intro": "Love being inspired and sharing inspiration.",
     "photo": "https://raw.githubusercontent.com/iplayground/SessionData/2025/v1/images/speakers/speaker_13.jpg",
-    "url": "https://www.ethanhuang13.com",
+    "url": "https://ethanhuang13.plus",
     "fb": "",
     "github": "https://github.com/ethanhuang13",
     "linkedin": "",
-    "threads": "https://threads.net/ethanhuang13",
+    "threads": "https://threads.com/ethanhuang13",
     "x": "https://x.com/ethanhuang13",
     "hackMD": "",
     "seminar": ""

--- a/speakers_jp.json
+++ b/speakers_jp.json
@@ -362,14 +362,14 @@
   {
     "id": 25,
     "name": "13",
-    "title": "iOS Developer+",
-    "intro": "喜歡分享，不賣焦慮。Love being inspired and sharing inspiration. ➕iOS Developer+、📰Apple 開發者週報、🎙️weak self podcast",
+    "title": "Apple Dev Weekly の著者、weak self ポッドキャストのホスト。13+ の購読をお待ちしています",
+    "intro": "インスピレーションを受けることと、インスピレーションを共有することを愛しています。",
     "photo": "https://raw.githubusercontent.com/iplayground/SessionData/2025/v1/images/speakers/speaker_13.jpg",
-    "url": "https://www.ethanhuang13.com",
+    "url": "https://ethanhuang13.plus",
     "fb": "",
     "github": "https://github.com/ethanhuang13",
     "linkedin": "",
-    "threads": "https://threads.net/ethanhuang13",
+    "threads": "https://threads.com/ethanhuang13",
     "x": "https://x.com/ethanhuang13",
     "hackMD": "",
     "seminar": ""

--- a/staffs.json
+++ b/staffs.json
@@ -1,9 +1,9 @@
 [
 	{
 	  "name": "13",
-	  "title": "iOS Developer+",
+	  "title": "Apple 開發者週報作者、weak self podcast 主持人。歡迎訂閱 13+ 專欄",
 	  "photo": "https://raw.githubusercontent.com/iplayground/SessionData/2025/v1/images/staff/staff_13.jpeg",
-	  "url": "https://gravatar.com/ethanhuang13"
+	  "url": "https://ethanhuang13.plus"
 	},
 	{
 	  "name": "Andy",


### PR DESCRIPTION
- Changed speaker title and intro for speaker ID 25 to reflect current roles and interests.
- Updated URLs for personal website and social media platforms.
- Ensured consistency in speaker details across English, Japanese, and Traditional Chinese JSON files.