### PR TITLE
Feature/update-hackmd-links

### DIFF
--- a/schedule.json
+++ b/schedule.json
@@ -35,7 +35,7 @@
       "speaker": "鄭宇哲 UJ Cheng",
       "speakerID": 1,
       "description": "如何讓 Swift 程式碼更簡潔、可讀，是許多開發者追求的目標。函數式編程提供了一種更具表達力的寫法，讓我們能以直觀的語意處理資料與邏輯。本演講將介紹 Swift 到目前為止有的高階函數與使用技巧，並實際示範它們如何應用在 iOS 專案開發中，甚至是在刷題過程中。無論是提升演算法解題效率，還是改善專案架構，Functional Programming 都能為你的 Swift 程式碼帶來優雅的轉變。",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/S1rVR6Zugl"
     },
     {
       "time": "10:40 – 10:55",
@@ -56,7 +56,7 @@
       "speaker": "zonble",
       "speakerID": 3,
       "description": "Swift C++ Interop 是在 2020 年左右開始開發，在 2023 年 WWDC 上宣布的特性，這幾年也不斷有新的變化。在這個 talk 中，會提到如何在 Swift 專案中混用 C++ 語法，以及使用時會遇到的限制與挑戰。",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/ryTTTJMOxe"
     },
     {
       "time": "11:15 – 11:35",
@@ -69,8 +69,8 @@
       ],
       "speaker": "秋勇紀",
       "speakerID": 4,
-      "description": "This talk explores the evolving concept of performance in Swift, focusing on SE-0453, which introduces InlineArray—a fixed-size array type offering performance benefits over traditional Array. It addresses why InlineArray was introduced, when to use it, and what performance truly means in Swift. By diving into memory models (heap, stack, buffer), array history, and real-world performance implications, the talk aims to deepen understanding and reveal Swift’s potential on broader platforms, including embedded systems. Attendees will gain insights beyond everyday development, unlocking new perspectives on Swift’s roadmap and performance-driven future.",
-      "hackMD": ""
+      "description": "This talk explores the evolving concept of performance in Swift, focusing on SE-0453, which introduces InlineArray—a fixed-size array type offering performance benefits over traditional Array. It addresses why InlineArray was introduced, when to use it, and what performance truly means in Swift. By diving into memory models (heap, stack, buffer), array history, and real-world performance implications, the talk aims to deepen understanding and reveal Swift's potential on broader platforms, including embedded systems. Attendees will gain insights beyond everyday development, unlocking new perspectives on Swift's roadmap and performance-driven future.",
+      "hackMD": "https://hackmd.io/@iPlayground/HJUHAkzOeg"
     },
     {
       "time": "11:35 – 11:55",
@@ -84,7 +84,7 @@
       "speaker": "東東",
       "speakerID": 5,
       "description": "隨著 Apple 在 WWDC 2025 正式發布 Liquid Glass 設計語言，我們正見證繼 iOS 7 扁平化以來最重大的視覺革新。作為曾深度實作 Neumorphism 並應用於線上產品的開發者。本次分享將透過實際案例，深入探討 Neumorphism 與 Liquid Glass 的設計哲學，幫助大家從「什麼是好設計」進階到「為什麼這樣設計」的思維層次。",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/SJo_RkzOgl"
     },
     {
       "time": "11:55 – 12:15",
@@ -98,7 +98,7 @@
       "speaker": "林子祐",
       "speakerID": 6,
       "description": "這是一個從 Side Project 開始、卻意外成為全台超過 200 萬下載防災 App 的真實故事。《台灣地震速報 - Taiwan EEW》如何在資源有限的情況下，從一人開發逐步打造出穩定的全端地震預警系統？本場分享將介紹如何透過 Firebase Firestore 傳遞即時地震資料、以 AWS SNS 完成高速推播通知，並在 iOS 前端設計清晰直覺的 UI。該 App 曾獲選台灣 Apple App Store 年度排行榜第五名、取得相關專利、也成為中央氣象署的合作對象。這不僅是一段技術整合的經驗，也是一位開發者如何用有限資源撐起公共服務的實踐記錄",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/rylTCJfdeg"
     },
     {
       "time": "12:15 – 13:15",

--- a/schedule.json
+++ b/schedule.json
@@ -119,7 +119,7 @@
       "speaker": "qcl",
       "speakerID": 7,
       "description": "您是否曾經在動態島上看過動態通知？您知道LINE及其相關App也有動態通知嗎？\n\n在這次到分享中將會介紹動態通知的技術細節、實作過程中遇到的挑戰及在大型組織內推動新功能的經驗。",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/rkL71efuxe"
     },
     {
       "time": "14:05 – 14:20",
@@ -140,7 +140,7 @@
       "speaker": "Eric Chen",
       "speakerID": 8,
       "description": "架構的選擇從來不是「對」或「錯」，而是來自開發過程中的現實取捨。\n本場分享回顧講者在接手一個混亂 iOS 專案時，如何從基礎的 MVVM 出發，依據每個階段遇到的問題，逐步導入 Combine、Swift Concurrency、Repository、Closure DI，到最後設計出模組化的 Coordinator 架構。\n除了介紹技術選擇的實作方式，也會分享每一步背後的選擇動機與過程，讓你能從中找到可能適合自己團隊的做法。",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/HyaBJgf_ll"
     },
     {
       "time": "14:40 – 15:00",
@@ -154,7 +154,7 @@
       "speaker": "Vincent Chen",
       "speakerID": 9,
       "description": "本議程將分享自己一人接手大型專案的心路歷程。將分享如何面對長期未維護的程式碼，同時滿足排著隊的商業需求、A/B測試，以及從多面向優化使用者體驗。詳細會分享與不同團隊負責人協調、設定目標、迭代改善，以及導入新工具的實務經驗。最後，講者將分享對專案未來的展望與規劃。",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/Bkov1lMull"
     },
     {
       "time": "15:00 – 15:20",
@@ -167,8 +167,8 @@
       ],
       "speaker": "YC Hsu",
       "speakerID": 10,
-      "description": "TCA(The Composable Architecture) changed how we think about building apps. In this session, I’ll share our experience using TCA in production: what made us choose it, what surprised us, what helped us succeed, and what we suggest to you before you try TCA.",
-      "hackMD": ""
+      "description": "TCA(The Composable Architecture) changed how we think about building apps. In this session, I'll share our experience using TCA in production: what made us choose it, what surprised us, what helped us succeed, and what we suggest to you before you try TCA.",
+      "hackMD": "https://hackmd.io/@iPlayground/ry09yxMugg"
     },
     {
       "time": "15:20 – 15:40",
@@ -189,7 +189,7 @@
       "speaker": "Art",
       "speakerID": 11,
       "description": "從單向資料流出發，TCA 歷經 Dependency、Reducer Protocol、Navigation、Macro、Observation、Sharing State 等七次關鍵「突變」，Point-Free 以實驗般的嚴謹與巧思，逐步把凌亂樣板淬煉成高可測、易組裝的架構雨林。本場次將帶你拆解每一次演化背後的痛點、策略與收穫，一窺現代 iOS 架構的進化路徑。",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/HkV0JxM_xx"
     },
     {
       "time": "16:30 – 16:45",
@@ -210,7 +210,7 @@
       "speaker": "高海峰 Hai Feng Kao",
       "speakerID": 12,
       "description": "Swift Concurrency 將在 Swift 6 中全面啟用，這雖然提升了安全性，卻也讓原本看似合理的程式碼突然無法編譯。本議程將帶你深入理解常見錯誤訊息背後的原理，解析 @MainActor、Sendable、nonisolated 等關鍵概念，並透過實際案例展示 Swift Concurrency 中容易踩到的地雷與解法。不論你是剛接觸並發，或已在大型專案中實戰，這場分享都能幫助你更穩健地迎接 Swift 6 的變革",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/B1l7xgGuex"
     },
     {
       "time": "17:05 – 17:25",
@@ -223,7 +223,7 @@
       "speaker": "Allen Lai",
       "speakerID": 13,
       "description": "因緣際會下成為公司 Staff Engineer 職位的 technical interviewer, 期間受到管理層與 HR 肯定。\n反思自己可能做對了什麼，並回顧作為 candidate 時的錯誤與教訓。\n藉由自己作為 candidate 與 interviewer 的雙重經驗，分享如何以健康的心態和充分的準備迎接面試與被面試，打造更友善的職場面試環境。",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/S1RSxeM_xe"
     },
     {
       "time": "17:25 – 17:45",
@@ -237,7 +237,7 @@
       "speaker": "Ben",
       "speakerID": 14,
       "description": "軟體和咖哩的研發有很多相似之處，至少在知識的脈絡上，軟體的開發經驗是幫助很多的。\n這不是逃避現實的夢，是一段用肉身證明脫離舒適圈只有不舒適的冒險旅程。軟體和咖哩雙線已經邁向第六年，有了第二間店，自家製的系統也持續進行中。從餐飲的第一線悟出產品開發的經驗，絕對是別的地方聽不到的經驗分享。",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/H1gcllfOgl"
     },
     {
       "time": "17:45 – 17:50",
@@ -283,7 +283,7 @@
       "speaker": "吳政賢 OAWU",
       "speakerID": 2,
       "description": "宗教與軟體開發可以做些什麼？身為沒有正職 App 職場經驗的後端工程師，如何就自己經驗開發出一款在 App Store 上評價不錯的作品。開發中又要考量到什麼？合作？設計？體驗？行銷？經營？我將在這場會議中分享這個 APP 的開發心得！",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/ryGBPgfugg"
     },
     {
       "time": "10:35 – 10:50",
@@ -304,7 +304,7 @@
       "speaker": "Harry 吳卓強",
       "speakerID": 15,
       "description": "在使用 AI 輔助寫程式數月後，我發現了意想不到的優勢和陷阱。本次演講分享了您在自媒體行銷文中找不到的 5 個教訓。",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/rkDPPxGOel"
     },
     {
       "time": "11:10 – 11:30",
@@ -318,7 +318,7 @@
       "speaker": "海總理",
       "speakerID": 16,
       "description": "過去半年嘗試用 Vibe Coding 的方式，每個月開發並上線一個產品。這場分享聚焦在實戰過程中與 AI 協作所獲得的心得，以及如何達成快速產出。",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/B1dYPlzuel"
     },
     {
       "time": "11:30 – 11:50",
@@ -332,7 +332,7 @@
       "speaker": "大軍",
       "speakerID": 17,
       "description": "你可能聽過 ChatGPT、LLaMA、GPT-4，這些超強的語言模型通常都住在雲端大機房。但你知道嗎？現在有辦法把它們塞進你的 iPhone，隨時隨地自己跑、自己回話、完全不上雲！\n\n這場分享要帶你看看我怎麼讓一隻草泥馬（LLaMA）住進 iPhone 裡，還能即時跟你聊天不 lag。不靠網路、不丟雲端，純靠本地算力，把 open source 的 llama.cpp 跑起來，從 Swift 包到 Metal GPU，實現「裝置端生成式 AI」。",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/SJAsPlz_le"
     },
     {
       "time": "11:50 – 12:10",
@@ -346,7 +346,7 @@
       "speaker": "Daiki Matsudate",
       "speakerID": 18,
       "description": "Smartphones are becoming digital wallets for our identities. In this session, we’ll explore how international standards like ISO/IEC 18013-5/7 and 23220 series are shaping the way governments and tech giants adopt mobile identity solutions. We’ll walk through Apple’s APIs for identity and age verification using mDLs and mDocs, and discuss real-world use cases that blend security, privacy, and user experience.",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/ryeCvxz_ge"
     },
     {
       "time": "12:10 – 13:10",
@@ -367,7 +367,7 @@
       "speaker": "彼得潘",
       "speakerID": 19,
       "description": "學習 Flutter & Jetpack Compose 後，彼得潘還是喜歡開發 Swift iOS App，但也發現了它們一些方便和好用的地方，本分享將介紹 Flutter、Jetpack Compose、Dart、Kotlin、VS Code & Android Studio 不錯的功能，期待 Swift、Xcode & SwiftUI 未來有一天也能擁有這些功能。",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/rJv1dlfuex"
     },
     {
       "time": "14:00 – 14:15",
@@ -388,7 +388,7 @@
       "speaker": "羊小咩",
       "speakerID": 20,
       "description": "寫App⼤家都說「要加密、要⽤ HTTPS、不要存明⽂」，但你有沒有想過，為什麼？ 很多時候我們只是照做，但不懂為什麼要這麼做。這場分享從開發者⾓度切入，介紹 OWASP Mobile Top 10 熱⾨資安問題，中間⼈攻擊、為什麼破解⼯具可以讓駭客直接翻你的底牌。資安不是額外⼯作，⽽是寫程 式的⼀部分。學會⽤加解密、MobSF、了解逆向攻擊⽅式，讓你從「照做」變「懂做」，不再只是知其然，也能知其所以然。",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/BkkWueGOll"
     },
     {
       "time": "14:35 – 14:55",
@@ -402,7 +402,7 @@
       "speaker": "Astrid Lin",
       "speakerID": 21,
       "description": "Adding new purchase types to mature apps is risky business. When KKBOX needed to introduce a new in-app purchase model, we couldn't afford to disrupt existing users. This talk shares our real-world experience using StoreKit 2 for new features while keeping the original StoreKit API for legacy flows. Learn the technical gotchas, App Store review surprises, and practical strategies for payment system evolution in production apps. Perfect for developers facing similar legacy modernization challenges.",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/H1omdxfuxl"
     },
     {
       "time": "14:55 – 15:15",
@@ -416,7 +416,7 @@
       "speaker": "Ethan",
       "speakerID": 22,
       "description": "人臉活體偵測是一種安全措施，用於驗證捕捉的人臉影像或影片是否屬於真人，而非照片、影片或面具。它是人臉辨識系統的重要組成部分，可以防止有人試圖透過提供虛假的人臉圖像來冒充他人。\n\n在人臉活體檢測在生成式 AI 時代變得尤為重要，原因核心在於：\n防止由 AI 生成或偽造的人臉冒充真實人類，用於身份驗證、訪問控制或身份識別。\n\n為什麼在這個時代特別重要：\n\n1. 深度偽造和 AI 換臉技術快速普及\n2. 身份驗證日益依賴生物識別\n3. AI 生成的身份能輕易繞過弱檢測機制\n4. 維護數位平台的信任與安全\"",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/BykYugz_ge"
     },
     {
       "time": "15:15 – 15:35",
@@ -437,7 +437,7 @@
       "speaker": "倪僑德 Aaron Ni",
       "speakerID": 23,
       "description": "想讓LLM使用自家的工具做事嗎？\n想讓LLM幫你用你想要的方式，加速開發中瑣碎的流程嗎？\n抑或是看著github上玲琅滿目的MCP service，想下載，卻又擔心裡面不知是否有暗藏什麼有資安風險，可能竊取你資料的邏輯嗎？那表示是時候，該由你自己寫一個了\n\n這場分享會帶你從 iOS 工程師的角度，一起搞懂 Model Context Protocol（MCP）到底定義了什麼，怎麼運作\n並以簡單的案例示範如何打造屬於自己的 MCP Tool，讓 Cursor、Windsurf 這類 AI 助手可以直接和你自己的工具對話，再也不用自己複製貼上自家API的結果給AI。\n歡迎所有對自動化、AI 協作、Swift 實作有興趣的朋友一起來交流",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/HkVsdxfuxe"
     },
     {
       "time": "16:25 – 16:40",
@@ -458,7 +458,7 @@
       "speaker": "劉信",
       "speakerID": 24,
       "description": "過去半個世紀內，我們在有效學習的科學理解上有長足的進展，可惜的是這些研究成果並不常被應用在個人的學習上。身為工程師，我們善於運用理論和科學思維來解決問題，但我們是否有用這個專長來面對「如何提升自身專業能力」這個問題？\n\n本議程會試著用工程師的語言，探討如何用工程思維來最佳化學習，並評估 AI 對學習帶來的威脅與機會。\n\nOver the last half-century, scientific understanding of how we learn has made significant strides.  Unfortunately, few of us apply those understandings to accelerate our growth.  As software engineers, we are experts at applying theory and scientific thinking to solve real-world problems, but have we applied the same mindset toward improving our own skills?\n\nIn this session, we'll use the language of software engineers to explore how we could use engineering principles to optimize our professional growth.  We'll also evaluate the threats and opportunities that AI brings to our growth.",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/HJanOez_el"
     },
     {
       "time": "17:00 – 17:20",
@@ -472,7 +472,7 @@
       "speaker": "13",
       "speakerID": 25,
       "description": "在合適的條件下，AI 可以快速產出優秀的程式碼。因此，未來將是許多人能輕鬆創造完全屬於自己軟體的時代。我將公開「透過 AI 工具打造完全屬於自己工作流程與生活風格的 Apps」的實驗過程，並且分享我對於 AI 會改變（或不會改變）人類哪些方面的看法。",
-      "hackMD": ""
+      "hackMD": "https://hackmd.io/@iPlayground/B141txfugg"
     },
     {
       "time": "17:20 – 17:30",

--- a/speakers.json
+++ b/speakers.json
@@ -11,7 +11,7 @@
     "linkedin": "https://www.linkedin.com/in/iamhands0me/",
     "threads": "https://www.threads.com/@iamhands0me",
     "x": "https://x.com/iamhands0me",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/S1rVR6Zugl",
     "seminar": ""
   },
   {
@@ -26,7 +26,7 @@
     "linkedin": "",
     "threads": "https://www.threads.com/@oawu.tw",
     "x": "",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/ryGBPgfugg",
     "seminar": ""
   },
   {
@@ -41,7 +41,7 @@
     "linkedin": "",
     "threads": "",
     "x": "https://x.com/zonble",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/ryTTTJMOxe",
     "seminar": ""
   },
   {
@@ -56,7 +56,7 @@
     "linkedin": "",
     "threads": "",
     "x": "https://x.com/___freddi___",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/HJUHAkzOeg",
     "seminar": ""
   },
   {
@@ -71,7 +71,7 @@
     "linkedin": "https://www.linkedin.com/in/dongdong867",
     "threads": "",
     "x": "",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/SJo_RkzOgl",
     "seminar": ""
   },
   {
@@ -86,7 +86,7 @@
     "linkedin": "https://linkedin.com/in/joelin79",
     "threads": "",
     "x": "",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/rylTCJfdeg",
     "seminar": ""
   },
   {
@@ -101,7 +101,7 @@
     "linkedin": "https://www.linkedin.com/in/qingchengli/",
     "threads": "https://www.threads.com/@qingchengli",
     "x": "https://x.com/qingchengli",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/rkL71efuxe",
     "seminar": ""
   },
   {
@@ -116,7 +116,7 @@
     "linkedin": "https://www.linkedin.com/in/yu-lingchen",
     "threads": "",
     "x": "",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/HyaBJgf_ll",
     "seminar": ""
   },
   {
@@ -131,7 +131,7 @@
     "linkedin": "",
     "threads": "",
     "x": "https://x.com/vince78718",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/Bkov1lMull",
     "seminar": ""
   },
   {
@@ -146,7 +146,7 @@
     "linkedin": "https://www.linkedin.com/in/yi-chin-hsu/",
     "threads": "",
     "x": "https://x.com/echim2021",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/ry09yxMugg",
     "seminar": ""
   },
   {
@@ -161,7 +161,7 @@
     "linkedin": "",
     "threads": "",
     "x": "https://x.com/jutoart",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/HkV0JxM_xx",
     "seminar": ""
   },
   {
@@ -176,7 +176,7 @@
     "linkedin": "",
     "threads": "https://www.threads.com/@haifengkao",
     "x": "",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/B1l7xgGuex",
     "seminar": ""
   },
   {
@@ -191,7 +191,7 @@
     "linkedin": "https://www.linkedin.com/in/shiuan-farn-lai-07b616136/",
     "threads": "",
     "x": "https://x.com/AllenEzailLai",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/S1RSxeM_xe",
     "seminar": ""
   },
   {
@@ -206,7 +206,7 @@
     "linkedin": "",
     "threads": "",
     "x": "https://x.com/iamkuni",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/H1gcllfOgl",
     "seminar": ""
   },
   {
@@ -221,7 +221,7 @@
     "linkedin": "",
     "threads": "https://www.threads.net/@harryworld",
     "x": "https://x.com/harryworld",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/rkDPPxGOel",
     "seminar": ""
   },
   {
@@ -236,7 +236,7 @@
     "linkedin": "https://www.linkedin.com/in/tzangms/",
     "threads": "https://www.threads.com/@the.oceanic.official",
     "x": "https://x.com/tzangms",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/B1dYPlzuel",
     "seminar": ""
   },
   {
@@ -251,7 +251,7 @@
     "linkedin": "",
     "threads": "",
     "x": "https://x.com/dagingingin",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/SJAsPlz_le",
     "seminar": ""
   },
   {
@@ -266,7 +266,7 @@
     "linkedin": "",
     "threads": "",
     "x": "https://x.com/d_date",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/ryeCvxz_ge",
     "seminar": ""
   },
   {
@@ -281,7 +281,7 @@
     "linkedin": "",
     "threads": "",
     "x": "",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/rJv1dlfuex",
     "seminar": ""
   },
   {
@@ -296,7 +296,7 @@
     "linkedin": "",
     "threads": "",
     "x": "",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/BkkWueGOll",
     "seminar": ""
   },
   {
@@ -311,7 +311,7 @@
     "linkedin": "https://www.linkedin.com/in/astridlin",
     "threads": "",
     "x": "https://x.com/astridtingan",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/H1omdxfuxl",
     "seminar": ""
   },
   {
@@ -326,7 +326,7 @@
     "linkedin": "https://www.linkedin.com/in/ethanfan",
     "threads": "",
     "x": "https://x.com/coolioxlr",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/BykYugz_ge",
     "seminar": ""
   },
   {
@@ -341,7 +341,7 @@
     "linkedin": "https://www.linkedin.com/in/aaron-ni-73ba60146",
     "threads": "",
     "x": "https://x.com/chiao3145",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/HkVsdxfuxe",
     "seminar": ""
   },
   {
@@ -356,7 +356,7 @@
     "linkedin": "https://www.linkedin.com/in/hsingliu/",
     "threads": "",
     "x": "https://x.com/automorphism",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/HJanOez_el",
     "seminar": ""
   },
   {
@@ -371,7 +371,7 @@
     "linkedin": "",
     "threads": "https://threads.com/ethanhuang13",
     "x": "https://x.com/ethanhuang13",
-    "hackMD": "",
+    "hackMD": "https://hackmd.io/@iPlayground/B141txfugg",
     "seminar": ""
   }
 ]


### PR DESCRIPTION
- Updated all remaining 20 hackMD fields in schedule.json
- Now both speakers.json (25/25) and schedule.json (25/25) have complete HackMD links
- All links sourced from provided CSV file mapping speakers to presentations
- Enhanced session data with direct links to presentation materials

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>