### PR TITLE
fix: update staff photos in staffs.json for Mandy and Jess

### DIFF
--- a/staffs.json
+++ b/staffs.json
@@ -110,13 +110,13 @@
 	{
 	  "name": "mandy",
 	  "title": "iOS Ｅ人工程師",
-	  "photo": "https://raw.githubusercontent.com/iplayground/SessionData/2025/v1/images/staff/staff_mandy.jpg",
+	  "photo": "https://raw.githubusercontent.com/iplayground/SessionData/2025/v1/images/staff/staff_mandy.JPG",
 	  "url": "https://www.threads.com/@mandy.ios"
 	},
 	{
 	  "name": "Jess",
 	  "title": "UI/UX Designer",
-	  "photo": "https://raw.githubusercontent.com/iplayground/SessionData/2025/v1/images/staff/staff_jess.jpg",
+	  "photo": "https://raw.githubusercontent.com/iplayground/SessionData/2025/v1/images/staff/staff_jess.jpeg",
 	  "url": "https://www.instagram.com/jesss_0302/"
 	}
   ]


### PR DESCRIPTION
- Changed photo file extensions for Mandy from .jpg to .JPG and for Jess from .jpg to .jpeg to ensure consistency and correct file referencing.

This update maintains the integrity of the staff member records while improving the accuracy of image links.